### PR TITLE
Improve Cmd logging

### DIFF
--- a/src/vulkan/wrapper/vk_entrypoints.py
+++ b/src/vulkan/wrapper/vk_entrypoints.py
@@ -54,6 +54,7 @@ static VKAPI_ATTR $return_type VKAPI_CALL
 wrapper_tramp_$name(
     $decl_params)
 {
+    int cmd_id = commands++;
     struct temporary_objects temp;
     list_inithead(&temp.objects);
 $handle_unwrap_logic
@@ -79,7 +80,7 @@ COMMAND_BLACKLIST = [
 def print_param(command, param, mode='input'):
     if param == 'result':
         return [
-            f"        VK_CMD_LOG_UNCONDITIONAL(\"  out: result: VkResult = %ld\", (int64_t) result);",
+            f"        VK_CMD_LOG_UNCONDITIONAL(\"  out: result: VkResult = %ld (id=%d)\", (int64_t) result, cmd_id);",
             f"        VK_CMD_FLUSH();",
         ]
     is_input = param.num_pointers == 0 or param.is_const
@@ -95,31 +96,47 @@ def print_param(command, param, mode='input'):
     token = 'in' if is_input else 'out'
     output = []
     if is_wrapped:
-        output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} (handle) = %p\", {param.name});");
+        output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} (handle) = %p (id=%d)\", {param.name}, cmd_id);");
     elif is_struct:
         if not param.num_pointers: # Impossible
             output.append(f"#error: Impossible case struct+non-ptr {command.name} {param}")
         elif is_array and is_ptr1:
             # VkObject[10]
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}[]: {param.type}\");");
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}[]: {param.type} (id=%d)\", cmd_id);");
             output.append(f"        for (uint32_t i = 0; i < {param.len if is_input else (f"*{param.len}" if param.len != "1" else "1")}; i++) {{")
-            output.append(f"            VK_CMD_LOG_UNCONDITIONAL(\"    {param.name}[%d]: {param.type}\", i);");
+            output.append(f"            VK_CMD_LOG_UNCONDITIONAL(\"    {param.name}[%d]: {param.type} (id=%d)\", i, cmd_id);");
             output.append(f"            VK_PRINT_{param.type}(\"      \", &{param.name}[i]);")
             output.append(f"        }}")
         elif is_ptr1:
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}*\");");
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}* (id=%d)\", cmd_id);");
             output.append(f"        VK_PRINT_{param.type}(\"    \", {param.name});")
         else:
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}** = %p\", {param.name});");
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}** = %p (id=%d)\", {param.name}, cmd_id);");
     else:
         if not param.num_pointers:
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} = %lx\", (int64_t){param.name});")
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} = %lx (id=%d)\", (int64_t){param.name}, cmd_id);")
+        elif is_array and is_ptr1:
+            # VkObject[10]
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}[]: {param.type} = %p (id=%d)\", {param.name}, cmd_id);");
+            count = param.len
+            deref = f"{param.name}[i]"
+            if param.len == 'null-terminated' or (param.type == 'void' and is_ptr1):
+                return output
+            if param.len == '1':
+                count = '1'
+            elif '->' in param.len:
+                count = count
+            elif param.len.startswith('p') and not is_input:
+                count = '*' + count
+            output.append(f"        for (uint32_t i = 0; i < {count}; i++) {{")
+            output.append(f"            VK_CMD_LOG_UNCONDITIONAL(\"    {param.name}[%d]: {param.type} = %lx (id=%d)\", i, (int64_t){param.name}[i], cmd_id);");
+            output.append(f"        }}")
         elif param.num_pointers and not is_input and param.type not in ("void", "Display", "xcb_connection_t"):
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: *{param.name}: {param.type} = %lx\", (int64_t)*{param.name});")
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: *{param.name}: {param.type} = %lx (id=%d)\", (int64_t)*{param.name}, cmd_id);")
         elif param.num_pointers:
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}{'*' * param.num_pointers} = %lx\", (int64_t){param.name});")
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type}{'*' * param.num_pointers} = %lx (id=%d)\", (int64_t){param.name}, cmd_id);")
         else:
-            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} = %lx\", (int64_t){param.name});");
+            output.append(f"        VK_CMD_LOG_UNCONDITIONAL(\"  {token}: {param.name}: {param.type} = %lx (id=%d)\", (int64_t){param.name}, cmd_id);");
             pass
     # output.append(f"    }}")
     # output.append(f"#endif")
@@ -152,7 +169,7 @@ def _generate_trampoline(command, dispatch_table="device->dispatch_table"):
         physical_device = "base->physical"
 
     # handle_unwrap_logic.append(f"#ifdef NEEDS_PRINTING_{command.name}")
-    handle_unwrap_logic.append(f"    VK_CMD_LOG(\"{command.name}\");")
+    handle_unwrap_logic.append(f"    VK_CMD_LOG(\"{command.name} (id=%d)\", cmd_id);")
     # handle_unwrap_logic.append(f"#endif")
 
     handle_unwrap_logic.append(f"")

--- a/src/vulkan/wrapper/vk_printer.c.mako
+++ b/src/vulkan/wrapper/vk_printer.c.mako
@@ -93,7 +93,7 @@ vk_print_${s.name}(int can_log_level, int log_level, FILE* fd, const char* prefi
             % else:
         for (uint32_t i = 0; i < count_${member.name}; i++) {
                 % if member.is_handle and get_wrapper_type_for_vk_type(member.type):
-            VK_CMD_LOG_FD(fd, "%s.${member.name}[%d]: ${member.typep} (handle) = %p", prefix, i, in_info->${member.name});
+            VK_CMD_LOG_FD(fd, "%s.${member.name}[%d]: ${member.typep} (handle) = %lx", prefix, i, (int64_t) in_info->${member.name}[i]);
                 % elif member.resolved_type in all_vk_types:
                     % if member.num_pointers == 2:
             #error "Not implemented ${member.text}"

--- a/src/vulkan/wrapper/vk_wrapper_trampolines_gen.py
+++ b/src/vulkan/wrapper/vk_wrapper_trampolines_gen.py
@@ -113,6 +113,8 @@ TEMPLATE_C = Template(COPYRIGHT + """\
 #include "vk_unwrappers.h"
 #include "vk_printers.h"
 
+_Atomic static int commands = 0;
+
 #define VK_PRINT_VkAccelerationStructureVersionInfoKHR(...)
 #define VK_PRINT_VkAccelerationStructureBuildGeometryInfoKHR(...)
 #define VK_PRINT_VkCuLaunchInfoNVX(...)

--- a/src/vulkan/wrapper/wrapper_debug.c
+++ b/src/vulkan/wrapper/wrapper_debug.c
@@ -231,6 +231,44 @@ void initialize_cmd_print_masks() {
         wrapper_printer_masks.f5 |= 0x0000000800000000ULL;
     }
 
+    if (strstr(mask_bcn, "debug1")) {
+        // full mask = 0x800000000200000000000000000000000000101000b0402005b008912070a0017000080000
+        // f0 0x0000000000080000 = vkQueueSubmit
+        // f0 0x0000001000000000 = vkCreateFence
+        // f0 0x0000002000000000 = vkDestroyFence
+        // f0 0x0000004000000000 = vkResetFences
+        // f0 0x0000010000000000 = vkWaitForFences
+        // f0 0x0020000000000000 = vkCreateBuffer
+        // f0 0x0080000000000000 = vkCreateBufferView
+        // f0 0x1000000000000000 = vkCreateImageView
+        // f0 0x2000000000000000 = vkDestroyImageView
+        // f0 0x4000000000000000 = vkCreateShaderModule
+        wrapper_printer_masks.f0 |= 0x70a0017000080000ULL;
+        // f1 0x0000000000000020 = vkCreateComputePipelines
+        // f1 0x0000000000000100 = vkCreatePipelineLayout
+        // f1 0x0000000000001000 = vkCreateDescriptorSetLayout
+        // f1 0x0000000000008000 = vkDestroyDescriptorPool
+        // f1 0x0000000000080000 = vkUpdateDescriptorSets
+        // f1 0x0000000010000000 = vkResetCommandPool
+        // f1 0x0000000020000000 = vkAllocateCommandBuffers
+        // f1 0x0000000080000000 = vkBeginCommandBuffer
+        // f1 0x0000000100000000 = vkEndCommandBuffer
+        // f1 0x0000000400000000 = vkCmdBindPipeline
+        // f1 0x0000200000000000 = vkCmdBindDescriptorSets
+        // f1 0x0040000000000000 = vkCmdDispatch
+        // f1 0x1000000000000000 = vkCmdCopyBuffer
+        // f1 0x2000000000000000 = vkCmdCopyImage
+        // f1 0x8000000000000000 = vkCmdCopyBufferToImage
+        wrapper_printer_masks.f1 |= 0xb0402005b0089120ULL;
+        // f2 0x0000000000001000 = vkCmdPipelineBarrier
+        // f2 0x0000000000100000 = vkCmdPushConstants
+        wrapper_printer_masks.f2 |= 0x0000000000101000ULL;
+        // f4 0x0000000000000002 = vkBindBufferMemory2
+        // f4 0x0000008000000000 = vkGetBufferMemoryRequirements2
+        wrapper_printer_masks.f4 |= 0x0000008000000002ULL;
+    }
+
+
 // #define CHECK_CMD_MASK(cmd) \
 //     if (strstr(mask_bcn, #cmd)) SET_VK_ID_##cmd##_ON(wrapper_printer_masks);
 //     UNROLL_ENTRY_POINTS(CHECK_CMD_MASK)


### PR DESCRIPTION
1. Add missing cmd logging, such as dereferencing out-pointers, non-struct arrays, etc
2. Add debug1 as a cmd logging option, which dumps lots of useful commands related to our compute shader