### PR TITLE
Initial version of FixMaliSpecCompositeConstantsPass for Mali devices to address #93

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .venv/
 s3tc2.comp
 src/vulkan/wrapper/lib/
+.idea

--- a/src/vulkan/wrapper/include/spirv-tools/spirv-tools/libspirv.h
+++ b/src/vulkan/wrapper/include/spirv-tools/spirv-tools/libspirv.h
@@ -80,6 +80,8 @@ typedef enum spv_result_t {
   SPV_ERROR_INVALID_DATA = -14,  // Indicates data rules validation failure.
   SPV_ERROR_MISSING_EXTENSION = -15,
   SPV_ERROR_WRONG_VERSION = -16,  // Indicates wrong SPIR-V version
+  SPV_ERROR_FNVAR =
+      -17,  // Error related to SPV_INTEL_function_variants extension
   SPV_FORCE_32_BIT_ENUM(spv_result_t)
 } spv_result_t;
 

--- a/src/vulkan/wrapper/include/spirv-tools/spirv-tools/linker.hpp
+++ b/src/vulkan/wrapper/include/spirv-tools/spirv-tools/linker.hpp
@@ -67,12 +67,36 @@ class SPIRV_TOOLS_EXPORT LinkerOptions {
     allow_ptr_type_mismatch_ = allow_ptr_type_mismatch;
   }
 
+  std::string GetFnVarTargetsCsv() const { return fnvar_targets_csv_; }
+  void SetFnVarTargetsCsv(std::string fnvar_targets_csv) {
+    fnvar_targets_csv_ = fnvar_targets_csv;
+  }
+
+  std::string GetFnVarArchitecturesCsv() const {
+    return fnvar_architectures_csv_;
+  }
+  void SetFnVarArchitecturesCsv(std::string fnvar_architectures_csv) {
+    fnvar_architectures_csv_ = fnvar_architectures_csv;
+  }
+
+  bool GetHasFnVarCapabilities() const { return has_fnvar_capabilities_; }
+  void SetHasFnVarCapabilities(bool fnvar_capabilities) {
+    has_fnvar_capabilities_ = fnvar_capabilities;
+  }
+
+  std::vector<std::string> GetInFiles() const { return in_files_; }
+  void SetInFiles(std::vector<std::string> in_files) { in_files_ = in_files; }
+
  private:
   bool create_library_{false};
   bool verify_ids_{false};
   bool allow_partial_linkage_{false};
   bool use_highest_version_{false};
   bool allow_ptr_type_mismatch_{false};
+  std::string fnvar_targets_csv_{""};
+  std::string fnvar_architectures_csv_{""};
+  bool has_fnvar_capabilities_ = false;
+  std::vector<std::string> in_files_{{}};
 };
 
 // Links one or more SPIR-V modules into a new SPIR-V module. That is, combine

--- a/src/vulkan/wrapper/include/spirv-tools/spirv-tools/optimizer.hpp
+++ b/src/vulkan/wrapper/include/spirv-tools/spirv-tools/optimizer.hpp
@@ -1035,6 +1035,8 @@ Optimizer::PassToken CreateCanonicalizeIdsPass();
 
 // MALI-specific pass
 Optimizer::PassToken CreateRemoveClipCullDistPass();
+
+Optimizer::PassToken CreateFixMaliSpecConstantCompositePass();
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/src/vulkan/wrapper/spirv_edit.cpp
+++ b/src/vulkan/wrapper/spirv_edit.cpp
@@ -1,4 +1,6 @@
 #include "spirv_edit.h"
+
+#include <cstring>
 #include <iostream>
 #include <vector>
 #include <string>
@@ -114,7 +116,6 @@ int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_coun
     return 0;
 }
 
-
 extern "C"
 int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out) {
     _Atomic static int counter = 0;
@@ -132,8 +133,6 @@ int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_wor
         optimizer.RegisterPass(spvtools::CreateAggressiveDCEPass());
     }
 
-    WLOGD("Original SPIR-V Word Count %d (id=%d)", spirv_word_count, id);
-
     std::vector<uint32_t> optimized_binary;
     bool success = optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary);
 
@@ -141,8 +140,6 @@ int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_wor
         WLOGE("SPIRV editing failed");
         return 1;
     }
-
-    WLOGD("Lowered SPIR-V Word Count %d (id=%d)", optimized_binary.size(), id);
 
     if (optimized_binary.size() != spirv_word_count) {
         if (CHECK_FLAG("LOG_DISASSEMBLY"))
@@ -159,4 +156,41 @@ int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_wor
     std::memcpy(out->spirv_code, optimized_binary.data(), optimized_binary.size() * 4);
 
     return 0;
+}
+
+// TODO: redesign the spirv passes to avoid calling two separate passes
+extern "C"
+int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out) {
+   _Atomic static int counter = 0;
+   int id = counter++;
+   spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
+
+   optimizer.SetMessageConsumer([&](spv_message_level_t level, const char* source, const spv_position_t& position, const char* message) {
+       OptimizerMessageConsumer(level, source, position, message, id);
+   });
+
+   // Mali specific pass
+   optimizer.RegisterPass(spvtools::CreateFixMaliSpecConstantCompositePass());
+
+   std::vector<uint32_t> optimized_binary;
+   bool success = optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary);
+
+   if (!success) {
+      WLOGE("SPIRV editing failed");
+      return 1;
+   }
+
+   if (optimized_binary.size() != spirv_word_count) {
+      LogDisassembly("Lowered", optimized_binary, id);
+   }
+
+   out->spirv_word_count = optimized_binary.size();
+   out->spirv_code = static_cast<uint32_t*>(malloc(optimized_binary.size() * 4));
+   if (!out->spirv_code) {
+      WLOGE("Failed to allocate memory for optimized SPIR-V (id=%d)", id);
+      return 1;
+   }
+   std::memcpy(out->spirv_code, optimized_binary.data(), optimized_binary.size() * 4);
+
+   return 0;
 }

--- a/src/vulkan/wrapper/spirv_edit.h
+++ b/src/vulkan/wrapper/spirv_edit.h
@@ -16,6 +16,8 @@ int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_coun
 
 int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out);
 
+int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out);
+
 void log_disassembly_to_cmd_log(const uint32_t* spirv_binary, size_t spirv_word_count);
 
 #ifdef __cplusplus

--- a/src/vulkan/wrapper/wrapper_device.c
+++ b/src/vulkan/wrapper/wrapper_device.c
@@ -19,6 +19,7 @@
 #include "vk_printers.h"
 #include "spirv_edit.h"
 #include "artifacts.h"
+#include "wrapper_checks.h"
 
 static const uint32_t s3tc_spv[] = {
 #include "s3tc.spv.h"
@@ -1746,28 +1747,52 @@ WRAPPER_CreateShaderModule(VkDevice device,
     const VkAllocationCallbacks* pAllocator,
     VkShaderModule* pShaderModule) {
    VK_FROM_HANDLE(wrapper_device, wdev, device);
-   bool needs_emulation = !wdev->physical->base_supported_features.shaderClipDistance && !CHECK_FLAG("DISABLE_CLIP_DISTANCE");
-
+   bool needs_clip_distance_emulation = !wdev->physical->base_supported_features.shaderClipDistance
+                                        && !CHECK_FLAG("DISABLE_CLIP_DISTANCE");
+   bool needs_spec_composite_constants_emulation = wdev->physical->driver_properties.driverID == VK_DRIVER_ID_ARM_PROPRIETARY
+                                                   && !CHECK_FLAG("DISABLE_SPEC_COMPOSITE_CONSTANTS");
    if (CHECK_FLAG("FORCE_CLIP_DISTANCE")) {
-      needs_emulation = true;
+      needs_clip_distance_emulation = true;
+   }
+   if (CHECK_FLAG("FORCE_SPEC_COMPOSITE_CONSTANTS")) {
+      needs_spec_composite_constants_emulation = true;
    }
 
-   if (!needs_emulation) {
-      return CHECK(CreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule));
+   VkShaderModuleCreateInfo ci = *pCreateInfo;
+   void* spirv1 = NULL;
+   if (needs_spec_composite_constants_emulation) {
+      const size_t orig_size = ci.codeSize;
+      const uint32_t* orig_code = ci.pCode;
+      struct SpirvCode lowered_spirv = { 0 };
+      if (fix_mali_spec_composite_constants(orig_code, orig_size / 4, &lowered_spirv)) {
+         WLOGE("fix_mali_spec_composite_constants failed");
+      } else {
+         ci.codeSize = lowered_spirv.spirv_word_count * 4;
+         ci.pCode = lowered_spirv.spirv_code;
+         spirv1 = lowered_spirv.spirv_code;
+      }
    }
 
-   size_t orig_size = pCreateInfo->codeSize;
-   const uint32_t* orig_code = pCreateInfo->pCode;
-   struct SpirvCode lowered = { 0 };
-   if (lower_eliminate_clip_distance(orig_code, orig_size / 4, &lowered)) {
-      WLOGE("lower_eliminate_clip_distance failed");
-      return CHECK(CreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule));
+   void* spirv2 = NULL;
+   if (needs_clip_distance_emulation) {
+      const size_t orig_size = ci.codeSize;
+      const uint32_t* orig_code = ci.pCode;
+      struct SpirvCode lowered_spirv = { 0 };
+      if (lower_eliminate_clip_distance(orig_code, orig_size / 4, &lowered_spirv)) {
+         WLOGE("lower_eliminate_clip_distance failed");
+      } else {
+         ci.codeSize = lowered_spirv.spirv_word_count * 4;
+         ci.pCode = lowered_spirv.spirv_code;
+         spirv2 = lowered_spirv.spirv_code;
+      }
    }
 
-   VkShaderModuleCreateInfo newCreateInfo = *pCreateInfo;
-   newCreateInfo.codeSize = lowered.spirv_word_count * 4;
-   newCreateInfo.pCode = lowered.spirv_code;
-   return CHECK(CreateShaderModule(device, &newCreateInfo, pAllocator, pShaderModule));
+   VkResult result = CHECK(CreateShaderModule(device, &ci, pAllocator, pShaderModule));
+
+   if (spirv1) free(spirv1);
+   if (spirv2) free(spirv2);
+
+   return result;
 }
 
 WRAPPER_CreateGraphicsPipelines(


### PR DESCRIPTION
See https://leegao.github.io/winlator-internals/2025/06/02/Vortek2.html

In dxvk 1.7.3, a pair of changes

1. https://github.com/doitsujin/dxvk/commit/45461ee54e691739abfae2edc61771b359302119
2. https://github.com/doitsujin/dxvk/commit/538b55921ecea72ef861d2b5da72ac20b109d2be

were introduced that introduces a specific pattern to check for texture/image binding state:

```
   %t0_bound = OpSpecConstantTrue %bool  ; true constant - whether or not this texture is actually bound by the pipeline
...
    %float_0 = OpConstant %float 0
         %44 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
     %v4bool = OpTypeVector %bool 4
         %46 = OpConstantComposite %v4bool %t0_bound %t0_bound %t0_bound %t0_bound
...
         %47 = OpSelect %v4float %46 %42 %44  ; still for %42
               OpStore %r0 %47
```

Unfortunately, this patterns seems to induce a latent shader compiler bug on some Mali drivers that cause this opselect to be wrongly optimized into the %44 = vec4(0,0,0,0), which in turn renders into a black screen.

This pass replaces the OpConstantComposite with OpSpecConstantComposite which does _not_ trigger this compiler bug.

The shader pass itself is implemented in https://github.com/leegao/SPIRV-Tools/pull/2 and is shipped as part of https://github.com/leegao/SPIRV-Tools/releases/tag/v0.0.2