### PR TITLE
Add mali optimization barriers pass

### DIFF
--- a/src/vulkan/wrapper/include/spirv-tools/spirv-tools/optimizer.hpp
+++ b/src/vulkan/wrapper/include/spirv-tools/spirv-tools/optimizer.hpp
@@ -1037,6 +1037,8 @@ Optimizer::PassToken CreateCanonicalizeIdsPass();
 Optimizer::PassToken CreateRemoveClipCullDistPass();
 
 Optimizer::PassToken CreateFixMaliSpecConstantCompositePass();
+
+Optimizer::PassToken CreateMaliOptimizationBarrierPass();
 }  // namespace spvtools
 
 #endif  // INCLUDE_SPIRV_TOOLS_OPTIMIZER_HPP_

--- a/src/vulkan/wrapper/spirv_edit.cpp
+++ b/src/vulkan/wrapper/spirv_edit.cpp
@@ -63,13 +63,16 @@ void OptimizerMessageConsumer(spv_message_level_t level, const char* source,
     case SPV_MSG_FATAL:
     case SPV_MSG_INTERNAL_ERROR:
     case SPV_MSG_ERROR:
-        WLOGE("SPIRV Error: " MSG)
+        WLOGE(".spv E: " MSG)
         break;
     case SPV_MSG_WARNING:
-        WLOGE("SPIRV Warning: " MSG)
+        WLOGE(".spv W: " MSG)
         break;
     case SPV_MSG_INFO:
-        WLOG("SPIRV Info: " MSG)
+        WLOG(".spv I: " MSG)
+        break;
+    case SPV_MSG_DEBUG:
+        WLOGD(".spv D: " MSG)
         break;
     default:
         break;

--- a/src/vulkan/wrapper/spirv_edit.cpp
+++ b/src/vulkan/wrapper/spirv_edit.cpp
@@ -80,7 +80,7 @@ void OptimizerMessageConsumer(spv_message_level_t level, const char* source,
 }
 
 extern "C"
-int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out) {
+int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out) {
     spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
 
     optimizer.SetMessageConsumer([&](spv_message_level_t level, const char* source, const spv_position_t& position, const char* message) {
@@ -120,7 +120,7 @@ int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_coun
 }
 
 extern "C"
-int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out) {
+int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out) {
     _Atomic static int counter = 0;
     int id = counter++;
     spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
@@ -137,10 +137,8 @@ int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_wor
     }
 
     std::vector<uint32_t> optimized_binary;
-    bool success = optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary);
-
-    if (!success) {
-        WLOGE("SPIRV editing failed");
+    if (!optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary)) {
+        WLOGE("RemoveClipDistancePass failed");
         return 1;
     }
 
@@ -163,7 +161,7 @@ int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_wor
 
 // TODO: redesign the spirv passes to avoid calling two separate passes
 extern "C"
-int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out) {
+int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out) {
    _Atomic static int counter = 0;
    int id = counter++;
    spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
@@ -176,10 +174,41 @@ int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv
    optimizer.RegisterPass(spvtools::CreateFixMaliSpecConstantCompositePass());
 
    std::vector<uint32_t> optimized_binary;
-   bool success = optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary);
+   if (!optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary)) {
+      WLOGE("FixMaliSpecConstantCompositePass failed");
+      return 1;
+   }
 
-   if (!success) {
-      WLOGE("SPIRV editing failed");
+   if (optimized_binary.size() != spirv_word_count) {
+      LogDisassembly("Lowered", optimized_binary, id);
+   }
+
+   out->spirv_word_count = optimized_binary.size();
+   out->spirv_code = static_cast<uint32_t*>(malloc(optimized_binary.size() * 4));
+   if (!out->spirv_code) {
+      WLOGE("Failed to allocate memory for optimized SPIR-V (id=%d)", id);
+      return 1;
+   }
+   std::memcpy(out->spirv_code, optimized_binary.data(), optimized_binary.size() * 4);
+
+   return 0;
+}
+
+extern "C"
+int add_optimization_barriers(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out) {
+   _Atomic static int counter = 0;
+   int id = counter++;
+   spvtools::Optimizer optimizer(SPV_ENV_VULKAN_1_1_SPIRV_1_4);
+
+   optimizer.SetMessageConsumer([&](spv_message_level_t level, const char* source, const spv_position_t& position, const char* message) {
+       OptimizerMessageConsumer(level, source, position, message, id);
+   });
+
+   optimizer.RegisterPass(spvtools::CreateMaliOptimizationBarrierPass());
+
+   std::vector<uint32_t> optimized_binary;
+   if (!optimizer.Run(spirv_binary, spirv_word_count, &optimized_binary)) {
+      WLOGE("AddOptimizationBarrierPass failed");
       return 1;
    }
 

--- a/src/vulkan/wrapper/spirv_edit.h
+++ b/src/vulkan/wrapper/spirv_edit.h
@@ -7,16 +7,18 @@
 extern "C" {
 #endif
 
-struct SpirvCode {
+typedef struct SpirvCode {
     uint32_t* spirv_code;
     size_t spirv_word_count;
-};
+} SpirvCode;
 
-int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out);
+int optimize_spirv_for_size(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out);
 
-int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out);
+int lower_eliminate_clip_distance(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out);
 
-int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, struct SpirvCode* out);
+int fix_mali_spec_composite_constants(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out);
+
+int add_optimization_barriers(const uint32_t* spirv_binary, size_t spirv_word_count, SpirvCode* out);
 
 void log_disassembly_to_cmd_log(const uint32_t* spirv_binary, size_t spirv_word_count);
 

--- a/src/vulkan/wrapper/wrapper_device.c
+++ b/src/vulkan/wrapper/wrapper_device.c
@@ -1751,20 +1751,24 @@ WRAPPER_CreateShaderModule(VkDevice device,
                                         && !CHECK_FLAG("DISABLE_CLIP_DISTANCE");
    bool needs_spec_composite_constants_emulation = wdev->physical->driver_properties.driverID == VK_DRIVER_ID_ARM_PROPRIETARY
                                                    && !CHECK_FLAG("DISABLE_SPEC_COMPOSITE_CONSTANTS");
+   bool needs_optimization_barriers = (wdev->physical->driver_properties.driverID == VK_DRIVER_ID_ARM_PROPRIETARY
+                                       || wdev->physical->driver_properties.driverID == VK_DRIVER_ID_QUALCOMM_PROPRIETARY)
+                                          && !CHECK_FLAG("DISABLE_OPTIMIZATION_BARRIERS");
    if (CHECK_FLAG("FORCE_CLIP_DISTANCE")) {
       needs_clip_distance_emulation = true;
    }
    if (CHECK_FLAG("FORCE_SPEC_COMPOSITE_CONSTANTS")) {
       needs_spec_composite_constants_emulation = true;
    }
+   if (CHECK_FLAG("FORCE_OPTIMIZATION_BARRIERS")) {
+      needs_optimization_barriers = true;
+   }
 
    VkShaderModuleCreateInfo ci = *pCreateInfo;
    void* spirv1 = NULL;
    if (needs_spec_composite_constants_emulation) {
-      const size_t orig_size = ci.codeSize;
-      const uint32_t* orig_code = ci.pCode;
-      struct SpirvCode lowered_spirv = { 0 };
-      if (fix_mali_spec_composite_constants(orig_code, orig_size / 4, &lowered_spirv)) {
+      SpirvCode lowered_spirv = { 0 };
+      if (fix_mali_spec_composite_constants(ci.pCode, ci.codeSize / 4, &lowered_spirv)) {
          WLOGE("fix_mali_spec_composite_constants failed");
       } else {
          ci.codeSize = lowered_spirv.spirv_word_count * 4;
@@ -1774,12 +1778,10 @@ WRAPPER_CreateShaderModule(VkDevice device,
    }
 
    void* spirv2 = NULL;
-   if (needs_clip_distance_emulation) {
-      const size_t orig_size = ci.codeSize;
-      const uint32_t* orig_code = ci.pCode;
-      struct SpirvCode lowered_spirv = { 0 };
-      if (lower_eliminate_clip_distance(orig_code, orig_size / 4, &lowered_spirv)) {
-         WLOGE("lower_eliminate_clip_distance failed");
+   if (needs_optimization_barriers) {
+      SpirvCode lowered_spirv = { 0 };
+      if (add_optimization_barriers(ci.pCode, ci.codeSize / 4, &lowered_spirv)) {
+         WLOGE("add_optimization_barriers failed");
       } else {
          ci.codeSize = lowered_spirv.spirv_word_count * 4;
          ci.pCode = lowered_spirv.spirv_code;
@@ -1787,10 +1789,23 @@ WRAPPER_CreateShaderModule(VkDevice device,
       }
    }
 
-   VkResult result = CHECK(CreateShaderModule(device, &ci, pAllocator, pShaderModule));
+   void* spirv3 = NULL;
+   if (needs_clip_distance_emulation) {
+      SpirvCode lowered_spirv = { 0 };
+      if (lower_eliminate_clip_distance(ci.pCode, ci.codeSize / 4, &lowered_spirv)) {
+         WLOGE("lower_eliminate_clip_distance failed");
+      } else {
+         ci.codeSize = lowered_spirv.spirv_word_count * 4;
+         ci.pCode = lowered_spirv.spirv_code;
+         spirv3 = lowered_spirv.spirv_code;
+      }
+   }
+
+   const VkResult result = CHECK(CreateShaderModule(device, &ci, pAllocator, pShaderModule));
 
    if (spirv1) free(spirv1);
    if (spirv2) free(spirv2);
+   if (spirv3) free(spirv3);
 
    return result;
 }


### PR DESCRIPTION
Fixed #161

For certain patterns (e.g. left-shifts by a constant value), these are often optimized into a buggy mess by ARM and Qcom shader compilers, potentially causing speculative execution of memory reads/writes and gpu faults.

This pass adds a BitFieldInsert 0,0,0 (a no-op that's not currently detected by the compilers) as an optimization barrier to prevent these ops from being wrongly folded by the optimizing compilers